### PR TITLE
Add defaults initializer and demo

### DIFF
--- a/defaults.c
+++ b/defaults.c
@@ -1,0 +1,35 @@
+#include "defaults.h"
+#include <string.h>
+
+void ths8200_set_defaults(ths8200_regs_t *r)
+{
+    if (!r) {
+        return;
+    }
+
+    memset(r, 0, sizeof(*r));
+
+    /*
+     * Populate registers with the non-zero power-on defaults from the
+     * THS8200 datasheet. Fields not listed are left cleared.
+     */
+
+    /* System control: software reset bit defaults high */
+    r->system.ctl.arst_func_n = true;
+
+    /* Data path control: default input format selector */
+    r->datapath.format = 0x03; /* data_dman_cntl = 011b */
+
+    /* Color Space Conversion defaults (Q2.8 coefficients) */
+    r->csc.r2r_int  = 0x00; r->csc.r2r_frac  = 0xDA;
+    r->csc.r2g_int  = (int8_t)0x80; r->csc.r2g_frac  = 0x78;
+    r->csc.r2b_int  = 0x02; r->csc.r2b_frac  = 0x0C;
+    r->csc.g2r_int  = 0x02; r->csc.g2r_frac  = 0xDC;
+    r->csc.g2g_int  = (int8_t)0x81; r->csc.g2g_frac  = 0x94;
+    r->csc.g2b_int  = (int8_t)0x81; r->csc.g2b_frac  = 0xDC;
+    r->csc.b2r_int  = 0x00; r->csc.b2r_frac  = 0x4A;
+    r->csc.b2g_int  = 0x02; r->csc.b2g_frac  = 0x0C;
+    r->csc.b2b_int  = (int8_t)0x80; r->csc.b2b_frac  = 0x30;
+    r->csc.yoff_int = 0x00; r->csc.yoff_frac = 0x08;
+    r->csc.cboff_int= 0x02; r->csc.cboff_frac= 0x00;
+}

--- a/defaults.h
+++ b/defaults.h
@@ -1,0 +1,10 @@
+#ifndef THS8200_DEFAULTS_H
+#define THS8200_DEFAULTS_H
+#include "ths8200.h"
+
+/**
+ * @brief Fill @p r with THS8200 register defaults.
+ */
+void ths8200_set_defaults(ths8200_regs_t *r);
+
+#endif /* THS8200_DEFAULTS_H */

--- a/main.c
+++ b/main.c
@@ -1,0 +1,10 @@
+#include "defaults.h"
+#include <stdio.h>
+
+int main(void)
+{
+    ths8200_regs_t regs;
+    ths8200_set_defaults(&regs);
+    ths8200_print_regs(&regs);
+    return 0;
+}

--- a/ths8200.h
+++ b/ths8200.h
@@ -113,12 +113,9 @@ typedef struct {
         uint8_t shift_gy;     /**< @0x47 */
         uint8_t shift_cb;     /**< @0x48 */
         uint8_t shift_cr;     /**< @0x49 */
-        uint8_t mult_gy_msb;  /**< @0x4A bits7-5 */
-        uint8_t mult_cb_msb;  /**< @0x4B bits5-3 */
-        uint8_t mult_cr_msb;  /**< @0x4B bits2-0 */
-        uint8_t mult_gy_lsb;  /**< @0x4C */
-        uint8_t mult_cb_lsb;  /**< @0x4D */
-        uint8_t mult_cr_lsb;  /**< @0x4E */
+        uint16_t mult_gy;     /**< 11-bit: 0x4A[7:5] MSB | 0x4C LSB */
+        uint16_t mult_cb;     /**< 11-bit: 0x4B[5:3] MSB | 0x4D LSB */
+        uint16_t mult_cr;     /**< 11-bit: 0x4B[2:0] MSB | 0x4E LSB */
         uint8_t csm_ctrl;     /**< @0x4F */
     } csm;
 


### PR DESCRIPTION
## Summary
- add functions to populate THS8200 register structure with default values
- demo program prints those defaults using the existing pretty-printer
- consolidate multiplier fields and print registers in decimal

## Testing
- `gcc -std=c99 -Wall -Wextra -c defaults.c`
- `gcc -std=c99 -Wall -Wextra -c ths8200.c`
- `gcc -std=c99 -Wall -Wextra -c main.c`


------
https://chatgpt.com/codex/tasks/task_e_686091537440832a89a3bb81f493b109